### PR TITLE
Use carbon stm32cube hal

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -125,7 +125,7 @@ manifest:
         - hal
     - name: hal_stm32
       remote: carbon
-      revision: carbon/master-v2
+      revision: b80405468538d358dc644f7c16951c6fc2cf6b14
       path: modules/hal/stm32
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,8 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 51b373cd3455b8c2b9babbf6ff41918116a442ac
+      remote: carbon
+      revision: carbon/master-v2
       path: modules/hal/stm32
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -21,6 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
+    - name: carbon
+      url-base: git@github.com:maka-autonomous-robotic-systems
 
   #
   # Please add items below based on alphabetical order


### PR DESCRIPTION
This change addresses [zephyr v2 crashes](https://app.asana.com/0/1200412916132010/1202851868019009/f).

Zephyr v2.6 uses the new STM32Cube v1.10 HAL but it retains the legacy ethernet driver. The legacy ethernet driver on zephyr's repo does not contain [the fix](https://github.com/carbonrobotics/hal_stm32/commit/8ac1e357d92797a0a76cfbe8aea24ca30199aae8) for leaking context descriptor due to race condition in `HAL_ETH_IsRxDataAvailable()`.

I created a [new branch](https://github.com/carbonrobotics/hal_stm32/tree/carbon/master-v2) on our `hal_stm32` repo and ported this fix to the legacy ethernet driver. This PR changes hal_stm32 to use our drivers rather than zephyr's. We should go back to using zephyr's when they implement the new v1.10 ethernet HAL interface. 