### PR TITLE
Scanner GD32 support

### DIFF
--- a/drivers/adc/adc_gd32.c
+++ b/drivers/adc/adc_gd32.c
@@ -174,7 +174,9 @@ static int adc_gd32_configure_sampt(const struct adc_gd32_config *cfg,
 {
 	uint8_t index = 0, offset;
 
-	if (acq_time != ADC_ACQ_TIME_DEFAULT) {
+	if (acq_time == ADC_ACQ_TIME_MAX) {
+		index = ARRAY_SIZE(acq_time_tbl) - 1;
+	} else if (acq_time != ADC_ACQ_TIME_DEFAULT) {
 		/* Acquisition time unit is adc clock cycle. */
 		if (ADC_ACQ_TIME_UNIT(acq_time) != ADC_ACQ_TIME_TICKS) {
 			return -EINVAL;

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -182,7 +182,9 @@ static int eeprom_at2x_write(const struct device *dev, off_t offset,
 
 	while (len) {
 		ret = config->write_fn(dev, offset, pbuf, len);
+#if CONFIG_BOARD_SCANNER_GD
 		k_msleep(10);
+#endif
 		if (ret < 0) {
 			LOG_ERR("failed to write to EEPROM (err %d)", ret);
 #if ANY_INST_HAS_WP_GPIOS

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -182,6 +182,7 @@ static int eeprom_at2x_write(const struct device *dev, off_t offset,
 
 	while (len) {
 		ret = config->write_fn(dev, offset, pbuf, len);
+		k_msleep(10);
 		if (ret < 0) {
 			LOG_ERR("failed to write to EEPROM (err %d)", ret);
 #if ANY_INST_HAS_WP_GPIOS

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -260,6 +260,13 @@
 			label = "EXTI";
 		};
 
+		fwdgt: watchdog@40003000 {
+			compatible = "gd,gd32-fwdgt";
+			reg = <0x40003000 0x400>;
+			label = "FWDGT";
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@40020000 {
 			compatible = "gd,gd32-pinctrl-af";
 			reg = <0x40020000 0x2400>;

--- a/soc/arm/gigadevice/gd32f4xx/Kconfig.series
+++ b/soc/arm/gigadevice/gd32f4xx/Kconfig.series
@@ -9,5 +9,6 @@ config SOC_SERIES_GD32F4XX
 	select CPU_CORTEX_M4
 	select SOC_FAMILY_GD32_ARM
 	select GD32_HAS_AF_PINMUX
+	select GD32_HAS_IRC_32K
 	help
 	  Enable support for GigaDevice GD32F4XX MCU series


### PR DESCRIPTION
These are the remaining changes i've had to make to zephyr for GD32 scanner to work.

Note there is a hacky change to i2c eeprom driver where it sleeps 10 ms on every read/write because stop bit is not being interacted with properly. I believe this is a deeper issue with GD32 I2C hal usage that I haven't investigated yet.