### PR TITLE
Build fixes for gcc13

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -39,7 +39,21 @@ if(NOT DEFINED NOSYSDEF_CFLAG)
   set(NOSYSDEF_CFLAG -undef)
 endif()
 
-foreach(file_name include/stddef.h include-fixed/limits.h)
+# GCC-13, does not install limits.h on include-fixed anymore
+# https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=be9dd80f933480
+# Add check for GCC version >= 13.1
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} -dumpversion
+    OUTPUT_VARIABLE temp_compiler_version
+    )
+
+if("${temp_compiler_version}" VERSION_GREATER_EQUAL 13.1.0)
+    set(fix_header_file include/limits.h)
+else()
+    set(fix_header_file include-fixed/limits.h)
+endif()
+
+foreach(file_name include/stddef.h "${fix_header_file}")
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}
     OUTPUT_VARIABLE _OUTPUT


### PR DESCRIPTION
Pull in upstream fixes to enable building on gcc13 or later ([0b1dd29: gcc/target.cmake: fix build with gcc-13](https://github.com/zephyrproject-rtos/zephyr/commit/0b1dd29799e0651056250253c2288894dc1af86c)); this addresses build errors like the following:

```
CMake Error in CMakeLists.txt:
  Target "zephyr_interface" contains relative path in its
  INTERFACE_INCLUDE_DIRECTORIES:

    "include-fixed"
```