### PR TITLE
eth_stm32: write PHY registers for fixed link

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -88,11 +88,34 @@ config ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
 	  Set the RX idle timeout period in milliseconds after which the
 	  PHY's carrier status is re-evaluated.
 
+config ETH_STM32_RESET_ON_INIT
+	bool "Reset PHY during initialization"
+	default n
+	help
+	  Enable this to force a reset of the PHY during initialization, either via software or
+	  through a software reset sequence.
+
 config ETH_STM32_AUTO_NEGOTIATION_ENABLE
 	bool "Autonegotiation mode"
 	default y
 	help
 	  Enable this if using autonegotiation
+
+config ETH_STM32_MDI_X
+	bool "Whether MDI-X is enabled"
+	default y
+	help
+	  Set this to enable MDI-X on the PHY if supported to change
+
+if !ETH_STM32_MDI_X
+
+config ETH_STM32_MDI_CH_SWAP
+	bool "Swap TX and RX pairs"
+	help
+	  When selected, TX pair receives, RX pair transmits (crossover function) otherwise
+	  TX pair transmits, RX pair receives (straight through function, default)
+
+endif # !ETH_STM32_MDI_X
 
 if !ETH_STM32_AUTO_NEGOTIATION_ENABLE
 

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -6,6 +6,7 @@
 #ifndef ZEPHYR_DRIVERS_ETHERNET_ETH_STM32_HAL_PRIV_H_
 #define ZEPHYR_DRIVERS_ETHERNET_ETH_STM32_HAL_PRIV_H_
 
+#include <drivers/gpio.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
@@ -30,6 +31,20 @@ struct eth_stm32_hal_dev_cfg {
 	struct stm32_pclken pclken_ptp;
 #endif /* !defined(CONFIG_SOC_SERIES_STM32H7X) */
 	const struct pinctrl_dev_config *pcfg;
+
+	// optional PHY reset line
+	struct gpio_dt_spec phyReset;
+
+	// is the fixed-link prop present?
+	uint16_t force			: 1;
+	// desired link speed (mbps)
+	uint16_t forceSpeed		: 12;
+	// force full duplex?
+	uint16_t forceDuplex		: 1;
+	// enable MDI-X
+	uint16_t mdix			: 1;
+	// swap RX/TX pairs if MDI-X disable
+	uint16_t ch_swap		: 1;
 };
 
 /* Device run time data */

--- a/dts/bindings/ethernet/st,stm32-ethernet.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet.yaml
@@ -20,3 +20,7 @@ properties:
       required: true
     pinctrl-names:
       required: true
+    reset-gpios:
+      type: phandle-array
+      required: false
+      description: Optional hardware reset line for PHY; used in lieu of soft reset if available


### PR DESCRIPTION
Various tweaks to the STM32 Ethernet driver to make it work more reliably in our use case:

- Support resetting the PHY (via reset GPIO or soft reset)
- Initialize PHY configuration for fixed link speeds
  - This is based on the existing Kconfig settings, rather than any configuration in the device tree.
- Allow configuring Auto MDI-X