### PR TITLE
adc_stm32: Fix shared ADC IRQs for STM32H7xx

### DIFF
--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -12,7 +12,7 @@ config ADC_STM32
 	help
 	  Enable the driver implementation for the stm32xx ADC
 
-if SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
+if SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
 
 config ADC_STM32_SHARED_IRQS
 	bool "STM32 ADC shared interrupts"


### PR DESCRIPTION
Fix build issue when using ADC1 and ADC2 on STM32H7; this is caused by ADC1/2 sharing an interrupt vector. The ADC driver for STM32 can support this, but it wasn't yet implemented for STM32H7. This changes it such that ADC1/2 and ADC3 interrupt vectors will always be installed on STM32H7.