### PR TITLE
API to configure syslog server address at runtime

### DIFF
--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -11,6 +11,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log_output.h>
+#include <zephyr/net/net_pkt.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -296,6 +297,8 @@ static inline int log_backend_format_set(const struct log_backend *backend, uint
 
 	return backend->api->format_set(backend, log_type);
 }
+
+int log_backend_net_set_server(struct sockaddr *newAddr);
 
 /**
  * @}


### PR DESCRIPTION
Adds a function call (`log_backend_net_set_server()`) which can be used to override the syslog server address/port configured via Kconfig. This must be done _before_ the syslog backend is started.