### PR TITLE
API to set hostname at runtime

### DIFF
--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -28,6 +28,18 @@ extern "C" {
 	  sizeof("0011223344556677") - 1 : 0))
 
 /**
+ * @brief Set the device hostname
+ */
+#if defined(CONFIG_NET_HOSTNAME_ENABLE)
+int net_hostname_set(const char *newHostname);
+#else
+int net_hostname_set(const char *newHostname) {
+	return -ENOTSUP;
+}
+#endif
+
+
+/**
  * @brief Get the device hostname
  *
  * @details Return pointer to device hostname.

--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -236,3 +236,13 @@ const struct log_backend *log_backend_net_get(void)
 {
 	return &log_backend_net;
 }
+
+int log_backend_net_set_hostname(const char *newHostname) {
+	if(!newHostname) {
+		return -EFAULT;
+	}
+
+	strncpy(dev_hostname, newHostname, sizeof(dev_hostname));
+
+	return 0;
+}


### PR DESCRIPTION
Adds an API that allows setting the system hostname string at runtime. Also extended the syslog server to handle updating the client hostname as it changes.