### PR TITLE
Fix net_hostname_set declaration

### DIFF
--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -33,7 +33,7 @@ extern "C" {
 #if defined(CONFIG_NET_HOSTNAME_ENABLE)
 int net_hostname_set(const char *newHostname);
 #else
-int net_hostname_set(const char *newHostname) {
+static inline int net_hostname_set(const char *newHostname) {
 	return -ENOTSUP;
 }
 #endif


### PR DESCRIPTION
I broke this when backporting the API, if hostname support is disabled the function is declared in the header to always return `-ENOTSUP` but it also needs to be inline to avoid duplicate definitions