### PR TITLE
Add PTP packet interception to eth rx_thread

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -173,6 +173,11 @@ config ETH_STM32_HAL_PTP_CLOCK_INIT_PRIO
 	  a dependency from the network stack that this device
 	  initializes before network stack (NET_INIT_PRIO).
 
+config CARBON_PTP_USE_INTERCEPT
+	bool "Enable Carbon PTP hacks"
+	help
+	  Enable Carbon-specific PTP packet handling hacks.
+
 endif # SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
 
 endif # ETH_STM32_HAL

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -90,6 +90,12 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define __eth_stm32_buf  __aligned(4)
 #endif
 
+#ifdef CONFIG_CARBON_PTP_USE_INTERCEPT
+/* PTP slave callback functions */
+extern bool ptp_slave_is_active(void);
+extern int ptp_slave_process_packet(struct net_if *iface, struct net_pkt *pkt);
+#endif
+
 static ETH_DMADescTypeDef dma_rx_desc_tab[ETH_RXBUFNB] __eth_stm32_desc;
 static ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB] __eth_stm32_desc;
 static uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE] __eth_stm32_buf;
@@ -698,6 +704,13 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 							     vlan_tag));
 			}
 			while ((pkt = eth_rx(dev, &vlan_tag)) != NULL) {
+#if defined(CONFIG_CARBON_PTP_USE_INTERCEPT)
+				// check if PTP slave wants to handle this packet
+				if (ptp_slave_is_active() &&
+				    ptp_slave_process_packet(net_pkt_iface(pkt), pkt) == 0) {
+					continue;
+				}
+#endif
 				res = net_recv_data(net_pkt_iface(pkt), pkt);
 				if (res < 0) {
 					eth_stats_update_errors_rx(

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -92,8 +92,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #ifdef CONFIG_CARBON_PTP_USE_INTERCEPT
 /* PTP slave callback functions */
-extern bool ptp_slave_is_active(void);
-extern int ptp_slave_process_packet(struct net_if *iface, struct net_pkt *pkt);
+extern bool ptp_intercept_is_active(void);
+extern int ptp_intercept_process_packet(struct net_if *iface, struct net_pkt *pkt);
 #endif
 
 static ETH_DMADescTypeDef dma_rx_desc_tab[ETH_RXBUFNB] __eth_stm32_desc;
@@ -706,8 +706,8 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 			while ((pkt = eth_rx(dev, &vlan_tag)) != NULL) {
 #if defined(CONFIG_CARBON_PTP_USE_INTERCEPT)
 				// check if PTP slave wants to handle this packet
-				if (ptp_slave_is_active() &&
-				    ptp_slave_process_packet(net_pkt_iface(pkt), pkt) == 0) {
+				if (ptp_intercept_is_active() &&
+				    ptp_intercept_process_packet(net_pkt_iface(pkt), pkt) == 0) {
 					continue;
 				}
 #endif


### PR DESCRIPTION
Process PTP packets in the ethernet rx_thread so that we don't have to use raw sockets.
Related https://github.com/carbonrobotics/robot/pull/7456