### PR TITLE
Callbacks from Ethernet RX threads

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -105,6 +105,16 @@ static uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __eth_stm32_buf;
 static ETH_TxPacketConfig tx_config;
 #endif
 
+/**
+ * @brief Callback for every received packet (L2)
+ *
+ * Implement in app firmware to handle stuff (such as petting watchdogs) while stuck in the receive
+ * thread.
+ */
+void __weak __carbon_eth_rx_callback_l2() {
+	/* nothing */
+}
+
 static HAL_StatusTypeDef read_eth_phy_register(ETH_HandleTypeDef *heth,
 						uint32_t PHYAddr,
 						uint32_t PHYReg,
@@ -719,6 +729,9 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 						"into RX queue: %d", res);
 					net_pkt_unref(pkt);
 				}
+
+				// packet RX callback (for watchdog petting)
+				__carbon_eth_rx_callback_l2();
 			}
 		} else if (res == -EAGAIN) {
 			/* semaphore timeout period expired, check link status */

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -39,6 +39,15 @@ static struct net_traffic_class tx_classes[NET_TC_TX_COUNT];
 #if NET_TC_RX_COUNT > 0
 static struct net_traffic_class rx_classes[NET_TC_RX_COUNT];
 #endif
+/**
+ * @brief Callback for every received packet (L3)
+ *
+ * Implement in app firmware to handle stuff (such as petting watchdogs) while stuck in the receive
+ * thread.
+ */
+void __weak __carbon_eth_rx_callback_l3() {
+	/* nothing */
+}
 
 #if NET_TC_RX_COUNT > 0 || NET_TC_TX_COUNT > 0
 static void submit_to_queue(struct k_fifo *queue, struct net_pkt *pkt)
@@ -248,6 +257,7 @@ static void tc_rx_handler(struct k_fifo *fifo)
 		}
 
 		net_process_rx_packet(pkt);
+		__carbon_eth_rx_callback_l3();
 	}
 }
 #endif


### PR DESCRIPTION
This adds two callbacks, `__carbon_eth_rx_callback_l2()` and `__carbon_eth_rx_callback_l3()` which are invoked from various points in the Ethernet stack. These default to no-ops (via weak linking) but applications shall define these functions to override the behaviour.