### PR TITLE
Zephyr and mcumgr stack overflow and buffer overrun bugfixes.

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -465,6 +465,14 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 		stack_obj_size = Z_KERNEL_STACK_SIZE_ADJUST(stack_size);
 		stack_buf_start = Z_KERNEL_STACK_BUFFER(stack);
 		stack_buf_size = stack_obj_size - K_KERNEL_STACK_RESERVED;
+		
+		/* Zephyr treats stack overflow as an app bug.  But
+		 * this particular overflow can be seen by static
+		 * analysis so needs to be handled somehow.
+		 */
+		if (K_KERNEL_STACK_RESERVED > stack_obj_size) {
+			k_panic();
+		}
 	}
 
 	/* Initial stack pointer at the high end of the stack object, may

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -124,19 +124,19 @@ config MCUMGR_BUF_SIZE
 	  In case when MCUMGR_SMP_SHELL is enabled this value should be set to
 	  at least SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
 
-config MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
+config MCUMGR_BUF_MIN_USER_DATA_SIZE
 	int
-	default 24 if MCUMGR_TRANSPORT_UDP && NET_IPV6
-	default 8 if MCUMGR_TRANSPORT_UDP && MCUMGR_TRANSPORT_UDP_IPV4
-	default 8 if MCUMGR_TRANSPORT_BT
+	default 24 if MCUMGR_SMP_UDP && NET_IPV6
+	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
+	default 8 if MCUMGR_SMP_BT
 	default 4
 	help
 	  Hidden option to determine minimum user data size.
 
-config MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE
+config MCUMGR_BUF_USER_DATA_SIZE
 	int "Size of mcumgr buffer user data"
-	range MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE 128
-	default MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
+	range MCUMGR_BUF_MIN_USER_DATA_SIZE 128
+	default MCUMGR_BUF_MIN_USER_DATA_SIZE
 	help
 	  The size, in bytes, of user data to allocate for each mcumgr buffer.
 

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -124,17 +124,24 @@ config MCUMGR_BUF_SIZE
 	  In case when MCUMGR_SMP_SHELL is enabled this value should be set to
 	  at least SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
 
-config MCUMGR_BUF_USER_DATA_SIZE
-	int "Size of mcumgr buffer user data"
-	default 24 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV6
-	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
+config MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
+	int
+	default 24 if MCUMGR_TRANSPORT_UDP && NET_IPV6
+	default 8 if MCUMGR_TRANSPORT_UDP && MCUMGR_TRANSPORT_UDP_IPV4
+	default 8 if MCUMGR_TRANSPORT_BT
 	default 4
 	help
+	  Hidden option to determine minimum user data size.
+
+config MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE
+	int "Size of mcumgr buffer user data"
+	range MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE 128
+	default MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
 	  The size, in bytes, of user data to allocate for each mcumgr buffer.
 
 	  Different mcumgr transports impose different requirements for this
 	  setting. A value of 4 is sufficient for UART, shell, and bluetooth.
-	  For UDP, the userdata must be large enough to hold a IPv4/IPv6 address.
+	  For UDP, the userdata must be large enough to hold IPv4/IPv6 addresses.
 
 config MCUMGR_SMP_NOTIFY_CALLBACK
 	bool "SMP Notify Callback"

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -137,6 +137,7 @@ config MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE
 	int "Size of mcumgr buffer user data"
 	range MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE 128
 	default MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
+	help
 	  The size, in bytes, of user data to allocate for each mcumgr buffer.
 
 	  Different mcumgr transports impose different requirements for this

--- a/subsys/mgmt/mcumgr/smp_udp.c
+++ b/subsys/mgmt/mcumgr/smp_udp.c
@@ -60,8 +60,8 @@ static struct configs configs = {
 #endif
 };
 
-BUILD_ASSERT(sizeof(struct sockaddr) <= CONFIG_MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE,
-	     "CONFIG_MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE must be >= sizeof(struct sockaddr)");
+BUILD_ASSERT(sizeof(struct sockaddr) <= CONFIG_MCUMGR_BUF_USER_DATA_SIZE,
+	     "CONFIG_MCUMGR_BUF_USER_DATA_SIZE must be >= sizeof(struct sockaddr)");
 
 #if CONFIG_MCUMGR_SMP_UDP_IPV4
 static int smp_udp4_tx(struct zephyr_smp_transport *zst, struct net_buf *nb)

--- a/subsys/mgmt/mcumgr/smp_udp.c
+++ b/subsys/mgmt/mcumgr/smp_udp.c
@@ -60,6 +60,9 @@ static struct configs configs = {
 #endif
 };
 
+BUILD_ASSERT(sizeof(struct sockaddr) <= CONFIG_MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE,
+	     "CONFIG_MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE must be >= sizeof(struct sockaddr)");
+
 #if CONFIG_MCUMGR_SMP_UDP_IPV4
 static int smp_udp4_tx(struct zephyr_smp_transport *zst, struct net_buf *nb)
 {


### PR DESCRIPTION
Pull in two commits,

- In Kconfig, help ensure a minimum data buffer size in mcumgr. 
- Add a fault, in Zephyr, not just mcumgr, if when a thread is created, it's stack is known to be too small than another minimum size.

In practice, make sure the mcumgr stack and udp rx buffer sizes are larger than the defaults, to try to avoid these issues.

todo: fixing a build err from the new kconfig setting change