### PR TITLE
fix ICMP error on UDP

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -236,6 +236,63 @@ static struct net_conn *conn_find_handler(uint16_t proto, uint8_t family,
 	return NULL;
 }
 
+ static void net_conn_change_callback(struct net_conn *conn,
+				     net_conn_cb_t cb, void *user_data)
+ {
+	NET_DBG("[%zu] connection handler %p changed callback",
+		conn - conns, conn);
+
+	conn->cb = cb;
+	conn->user_data = user_data;
+ }
+
+static int net_conn_change_remote(struct net_conn *conn,
+				  const struct sockaddr *remote_addr,
+				  uint16_t remote_port)
+{
+	NET_DBG("[%zu] connection handler %p changed remote",
+		conn - conns, conn);
+
+	if (remote_addr) {
+		if (IS_ENABLED(CONFIG_NET_IPV6) &&
+			remote_addr->sa_family == AF_INET6) {
+			memcpy(&conn->remote_addr, remote_addr,
+				sizeof(struct sockaddr_in6));
+
+			if (!net_ipv6_is_addr_unspecified(
+					&net_sin6(remote_addr)->
+					sin6_addr)) {
+				conn->flags |= NET_CONN_REMOTE_ADDR_SPEC;
+			}
+		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
+				remote_addr->sa_family == AF_INET) {
+			memcpy(&conn->remote_addr, remote_addr,
+				sizeof(struct sockaddr_in));
+
+			if (net_sin(remote_addr)->sin_addr.s_addr) {
+				conn->flags |= NET_CONN_REMOTE_ADDR_SPEC;
+			}
+		} else {
+			NET_ERR("Remote address family not set");
+			return -EINVAL;
+		}
+
+		conn->flags |= NET_CONN_REMOTE_ADDR_SET;
+	} else {
+		conn->flags &= ~NET_CONN_REMOTE_ADDR_SPEC;
+		conn->flags &= ~NET_CONN_REMOTE_ADDR_SET;
+	}
+
+	if (remote_port) {
+		conn->flags |= NET_CONN_REMOTE_PORT_SPEC;
+			net_sin(&conn->remote_addr)->sin_port = htons(remote_port);
+	} else {
+		conn->flags &= ~NET_CONN_REMOTE_PORT_SPEC;
+	}
+
+       return 0;
+}
+
 int net_conn_register(uint16_t proto, uint8_t family,
 		      const struct sockaddr *remote_addr,
 		      const struct sockaddr *local_addr,
@@ -248,6 +305,7 @@ int net_conn_register(uint16_t proto, uint8_t family,
 {
 	struct net_conn *conn;
 	uint8_t flags = 0U;
+	int ret;
 
 	conn = conn_find_handler(proto, family, remote_addr, local_addr,
 				 remote_port, local_port);
@@ -259,33 +317,6 @@ int net_conn_register(uint16_t proto, uint8_t family,
 	conn = conn_get_unused();
 	if (!conn) {
 		return -ENOENT;
-	}
-
-	if (remote_addr) {
-		if (IS_ENABLED(CONFIG_NET_IPV6) &&
-		    remote_addr->sa_family == AF_INET6) {
-			memcpy(&conn->remote_addr, remote_addr,
-			       sizeof(struct sockaddr_in6));
-
-			if (!net_ipv6_is_addr_unspecified(
-				    &net_sin6(remote_addr)->
-				    sin6_addr)) {
-				flags |= NET_CONN_REMOTE_ADDR_SPEC;
-			}
-		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
-			   remote_addr->sa_family == AF_INET) {
-			memcpy(&conn->remote_addr, remote_addr,
-			       sizeof(struct sockaddr_in));
-
-			if (net_sin(remote_addr)->sin_addr.s_addr) {
-				flags |= NET_CONN_REMOTE_ADDR_SPEC;
-			}
-		} else {
-			NET_ERR("Remote address family not set");
-			goto error;
-		}
-
-		flags |= NET_CONN_REMOTE_ADDR_SET;
 	}
 
 	if (local_addr) {
@@ -330,22 +361,25 @@ int net_conn_register(uint16_t proto, uint8_t family,
 		}
 	}
 
-	if (remote_port) {
-		flags |= NET_CONN_REMOTE_PORT_SPEC;
-		net_sin(&conn->remote_addr)->sin_port = htons(remote_port);
-	}
-
 	if (local_port) {
 		flags |= NET_CONN_LOCAL_PORT_SPEC;
 		net_sin(&conn->local_addr)->sin_port = htons(local_port);
 	}
 
-	conn->cb = cb;
-	conn->user_data = user_data;
+	net_conn_change_callback(conn, cb, user_data);
 	conn->flags = flags;
 	conn->proto = proto;
 	conn->family = family;
 	conn->context = context;
+
+	/*
+	 * Since the net_conn_change_remote() updates the flags in connection,
+	 * must to be called after set the flags to connection.
+	 */
+	ret = net_conn_change_remote(conn, remote_addr, remote_port);
+	if (ret) {
+		goto error;
+	}
 
 	if (handle) {
 		*handle = (struct net_conn_handle *)conn;
@@ -382,10 +416,14 @@ int net_conn_unregister(struct net_conn_handle *handle)
 	return 0;
 }
 
-int net_conn_change_callback(struct net_conn_handle *handle,
-			     net_conn_cb_t cb, void *user_data)
+int net_conn_update(struct net_conn_handle *handle,
+		    net_conn_cb_t cb,
+		    void *user_data,
+		    const struct sockaddr *remote_addr,
+		    uint16_t remote_port)
 {
 	struct net_conn *conn = (struct net_conn *)handle;
+	int ret;
 
 	if (conn < &conns[0] || conn > &conns[CONFIG_NET_MAX_CONN]) {
 		return -EINVAL;
@@ -395,13 +433,12 @@ int net_conn_change_callback(struct net_conn_handle *handle,
 		return -ENOENT;
 	}
 
-	NET_DBG("[%zu] connection handler %p changed callback",
-		conn - conns, conn);
 
-	conn->cb = cb;
-	conn->user_data = user_data;
+	net_conn_change_callback(conn, cb, user_data);
 
-	return 0;
+	ret = net_conn_change_remote(conn, remote_addr, remote_port);
+
+	return ret;
 }
 
 static bool conn_addr_cmp(struct net_pkt *pkt,

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -150,17 +150,22 @@ static inline int net_conn_unregister(struct net_conn_handle *handle)
 #endif
 
 /**
- * @brief Change the callback and user_data for a registered connection
- * handle.
+ * @brief Update the callback, user data, remote address, and port
+ * for a registered connection handle.
  *
  * @param handle A handle registered with net_conn_register()
  * @param cb Callback to be called
  * @param user_data User data supplied by caller.
+ * @param remote_addr Remote address
+ * @param remote_port Remote port
  *
  * @return Return 0 if the the change succeed, <0 otherwise.
  */
-int net_conn_change_callback(struct net_conn_handle *handle,
-			     net_conn_cb_t cb, void *user_data);
+int net_conn_update(struct net_conn_handle *handle,
+		    net_conn_cb_t cb,
+		    void *user_data,
+		    const struct sockaddr *remote_addr,
+		    uint16_t remote_port);
 
 /**
  * @brief Called by net_core.c when a network packet is received.

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1922,9 +1922,25 @@ static int recv_udp(struct net_context *context,
 
 	ARG_UNUSED(timeout);
 
+
+	/* If the context already has a connection handler, it means it's
+         * already registered. In that case, all we have to do is 1) update
+         * the callback registered in the net_context and 2) update the
+         * user_data and remote address and port using net_conn_update().
+         *
+         * The callback function passed to net_conn_update() must be the same
+         * function as the one passed to net_conn_register(), not the callback
+         * set for the net context passed by recv_udp().
+         */
 	if (context->conn_handler) {
-		net_conn_unregister(context->conn_handler);
-		context->conn_handler = NULL;
+		context->recv_cb = cb;
+		ret = net_conn_update(context->conn_handler,
+				      net_context_packet_received,
+				      user_data,
+				      context->flags & NET_CONTEXT_REMOTE_ADDR_SET ?
+					&context->remote : NULL,
+				      ntohs(net_sin(&context->remote)->sin_port));
+		return ret;
 	}
 
 	ret = bind_default(context);
@@ -2018,17 +2034,30 @@ static int recv_raw(struct net_context *context,
 
 	ARG_UNUSED(timeout);
 
-	context->recv_cb = cb;
-
+	/* If the context already has a connection handler, it means it's
+	 * already registered. In that case, all we have to do is 1) update
+	 * the callback registered in the net_context and 2) update the
+	 * user_data using net_conn_update().
+	 *
+	 * The callback function passed to net_conn_update() must be the same
+	 * function as the one passed to net_conn_register(), not the callback
+	 * set for the net context passed by recv_raw().
+	 */
 	if (context->conn_handler) {
-		net_conn_unregister(context->conn_handler);
-		context->conn_handler = NULL;
+		context->recv_cb = cb;
+		ret = net_conn_update(context->conn_handler,
+				      net_context_raw_packet_received,
+				      user_data,
+				      NULL, 0);
+		return ret;
 	}
 
 	ret = bind_default(context);
 	if (ret) {
 		return ret;
 	}
+
+	context->recv_cb = cb;
 
 	ret = net_conn_register(net_context_get_ip_proto(context),
 				net_context_get_family(context),


### PR DESCRIPTION
Address an issue where Zephyr network stack would output an "ICMP Destination Unreachable" message when two UDP packets were received simultaneously for a bound receiving socket.

Backport fixes from zephyrproject-rtos/zephyr#70021.