### PR TITLE
Same base address but also different

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -380,6 +380,7 @@ int can_mcan_init(const struct device *dev)
 	uint32_t mrba = 0;
 #ifdef CONFIG_CAN_STM32H7
 	mrba = (uint32_t)msg_ram;
+	mrba = 0x4000AC00;
 #endif
 #ifdef CONFIG_CAN_MCUX_MCAN
 	mrba = (uint32_t)msg_ram & CAN_MCAN_MRBA_BA_MSK;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -484,7 +484,7 @@
 				compatible = "st,stm32h7-fdcan";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x4000a400 0x400>, <0x4000ac00 0x6a0>;
+				reg = <0x4000a400 0x400>, <0x4000af50 0x350>;
 				reg-names = "m_can", "message_ram";
 				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
 				interrupts = <20 0>, <22 0>, <63 0>;


### PR DESCRIPTION
STM32 CAN driver gets upset with memory layout when using multiple CAN peripherals, preventing ASC and HH code from building off of main.

The driver wants to know the base SRAM address when configuring flags, but it wants to know the per-peripheral offset "base address" when working within the memory during runtime. This change allows the device tree to use the per-peripheral address for working SRAM while using the single base address for flag configuration

This driver was rewritten in Zephyr3