### PR TITLE
bme680: validate calibration at init

### DIFF
--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -68,7 +68,7 @@ static void bme680_calc_temp(struct bme680_data *data, uint32_t adc_temp)
 	data->calc_temp = ((data->t_fine * 5) + 128) >> 8;
 }
 
-static void bme680_calc_press(struct bme680_data *data, uint32_t adc_press)
+static int bme680_calc_press(struct bme680_data *data, uint32_t adc_press)
 {
 	int32_t var1, var2, var3, calc_press;
 
@@ -82,6 +82,14 @@ static void bme680_calc_press(struct bme680_data *data, uint32_t adc_press)
 	       + (((int32_t)data->par_p2 * var1) >> 1);
 	var1 = var1 >> 18;
 	var1 = ((32768 + var1) * (int32_t)data->par_p1) >> 15;
+	/* A corrupted readout can drive var1 to zero; the divisions below
+	 * would fault (SCB DIV_0_TRP), so reject the sample instead.
+	 */
+	if (var1 == 0) {
+		LOG_WRN("rejecting sample: pressure divisor is zero (par_p1=%u)",
+			data->par_p1);
+		return -EIO;
+	}
 	calc_press = 1048576 - adc_press;
 	calc_press = (calc_press - (var2 >> 12)) * ((uint32_t)3125);
 	/* This max value is used to provide precedence to multiplication or
@@ -105,6 +113,7 @@ static void bme680_calc_press(struct bme680_data *data, uint32_t adc_press)
 	data->calc_press = calc_press
 			   + ((var1 + var2 + var3
 			       + ((int32_t)data->par_p7 << 7)) >> 4);
+	return 0;
 }
 
 static void bme680_calc_humidity(struct bme680_data *data, uint16_t adc_humidity)
@@ -214,7 +223,7 @@ static int bme680_sample_fetch(const struct device *dev,
 	uint32_t adc_temp, adc_press;
 	uint16_t adc_hum, adc_gas_res;
 	int size = BME680_LEN_FIELD;
-	int ret;
+	int ret, calc_ret = 0;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
@@ -236,9 +245,11 @@ static int bme680_sample_fetch(const struct device *dev,
 
 	if (data->new_data) {
 		bme680_calc_temp(data, adc_temp);
-		bme680_calc_press(data, adc_press);
-		bme680_calc_humidity(data, adc_hum);
-		bme680_calc_gas_resistance(data, gas_range, adc_gas_res);
+		calc_ret = bme680_calc_press(data, adc_press);
+		if (calc_ret == 0) {
+			bme680_calc_humidity(data, adc_hum);
+			bme680_calc_gas_resistance(data, gas_range, adc_gas_res);
+		}
 	}
 
 	/* Trigger the next measurement */
@@ -248,7 +259,7 @@ static int bme680_sample_fetch(const struct device *dev,
 		return ret;
 	}
 
-	return 0;
+	return calc_ret;
 }
 
 static int bme680_channel_get(const struct device *dev,
@@ -394,6 +405,17 @@ static int bme680_init(const struct device *dev)
 	err = bme680_read_compensation(dev);
 	if (err < 0) {
 		return err;
+	}
+
+	/* A degraded bus can corrupt these reads into ACKed all-zeros (or
+	 * all-ones); genuine parts never have gain terms at either rail.
+	 * par_p1 == 0 would divide by zero in the pressure compensation.
+	 */
+	if (data->par_t1 == 0 || data->par_t1 == 0xFFFF ||
+	    data->par_p1 == 0 || data->par_p1 == 0xFFFF) {
+		LOG_ERR("calibration invalid (par_t1=%u par_p1=%u)",
+			data->par_t1, data->par_p1);
+		return -ENODEV;
 	}
 
 	err = bme680_reg_write(dev, BME680_REG_CTRL_HUM, BME680_HUMIDITY_OVER);


### PR DESCRIPTION
## Problem

While testing MCB firmware on TB1, I found sometimes the firmware crashes. From my investigation I found sometimes the calibration data read from the BME680 chip can be 0, which later causes a division by zero fault when calculating pressure. I did not find a reliable way to reproduce this issue. Sometimes it happens frequently, while other times there is no repro with 20 tries. This change hardens the BME680 driver by adding calibration sanity check at init and division by zero guard in `bme680_calc_press()`.

## Change

Two guards, no behavior change on healthy parts:

1. **Init sanity check** — after reading compensation, validate `par_t1`/`par_p1`
   against `0x0000`/`0xFFFF` (genuine parts never have these gain terms at either
   rail). On failure, init returns `-ENODEV`, so `device_is_ready()` reports the
   sensor unusable and the application can degrade instead of crashing.
2. **Divisor safe guard in `bme680_calc_press()`** — if the intermediate divisor is
   zero (corrupted readout driving `var1` to 0), reject the sample: fetch returns
   `-EIO` and the dependent humidity/gas calculations are skipped for that sample.
 

## Testing

- Builds clean for `reaper_module_controller` (prod, STM32H7).
- Since we don't have a reliable way to repro the issue, I tested with injected fault with one-line local edits forcing `par_p1 = 0`. The tests were done on TB1 with J-LINK attached for RTT logging:
  - **Healthy Path**: without injected fault. The firmware runs normally with no error saw in RTT. Running `list` command from MCB CLI returns normal looking data for both environ sensors.
  - **Init Fault Injection**: `par_p1` forced to 0 after the calibration read. Observed "calibration invalid" error message from RTT. The firmware did not crash.
  - **Fetch Fault Injection**: `par_p1` forced to 0 in `bme680_sample_fetch()` before `bme680_calc_press()`. Observed "pressure divisor is zero" error message from RTT. The firmware did not crash.
  